### PR TITLE
Add local registry authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 *.log
 # Uncencrypted secrets should not be committed. This doesn't stop it but if people follow the docs it'll help
+flux/auth
+flux/certs/kind/kind-registry.*
 flux/clusters/*/secrets/*.unc.yaml
 .iml
 .idea/


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Feature

## Linked tickets

[BRID-82](https://digicatapult.atlassian.net/browse/BRID-82) (duplicates ticket [BRID-78](https://digicatapult.atlassian.net/browse/BRID-78))

## High level description

There's an existing Kind registry created by `add-kind-cluster.sh`. This PR adds and enforces HSTS for it and provides local credentials for the user to log in with. On a local workstation, i.e. "externally", the registry can typically be accessed via https://localhost:5000. Within the cluster itself, nodes would use https://kind-registry:5000 instead.

[BRID-82]: https://digicatapult.atlassian.net/browse/BRID-82?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[BRID-78]: https://digicatapult.atlassian.net/browse/BRID-78?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ