### PR TITLE
Adding secret access key and ID

### DIFF
--- a/flux/clusters/bridgeai-prod/mlflow/values.yaml
+++ b/flux/clusters/bridgeai-prod/mlflow/values.yaml
@@ -43,3 +43,10 @@ postgresql:
         postgresql: 5432
 minio:
   enabled: false
+externalS3:
+  host: s3.eu-west-2.amazonaws.com
+  port: 443
+  bucket: bridgeai-model-artefacts
+  existingSecret: mlflow-s3
+  existingSecretAccessKeyIDKey: access_key_id
+  existingSecretKeySecretKey: secret_access_key


### PR DESCRIPTION
# Pull Request

## Checklist
- [X] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [X] Bug Fix

## Linked tickets

N/A

## High level description

Configures MLFlow to use S3 as an artefact store, we were previously using a local EFS filestore.

## Detailed description

This bug would prevent us from getting the artefacts in order to build model containers later in the pipeline.  This PR and accompanying IaC code in the terraform repo provide a user and IAM access key (the only supported method for accessing S3 in the chart) in order to access the artefact S3 bucket.


## Describe alternatives you've considered

Trying to use OIDC.

## Operational impact

Due to a lot of the artefacts currently being stored on disk, we will need to wipe the EFS PVC and the accompanying database records, the easiest way to achieve this is to wipe both PVCs and allow them to be rebuilt.

## Additional context

N/A