### PR TITLE
Fix upstream Bitnami URI protocol

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Github CODEOWNERS file
+
+# Global code-owners for this repository
+* @dblane-digicatapult @elisehaldane

--- a/flux/clusters/bridgeai-prod/airflow/source.yaml
+++ b/flux/clusters/bridgeai-prod/airflow/source.yaml
@@ -15,4 +15,5 @@ metadata:
   namespace: mlflow
 spec:
   interval: 10m0s
-  url: https://charts.bitnami.com/bitnami
+  type: "oci"
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/flux/clusters/bridgeai-prod/airflow/values.yaml
+++ b/flux/clusters/bridgeai-prod/airflow/values.yaml
@@ -72,6 +72,8 @@ airflow:
       value: "https://mlflow.dc-mlops.co.uk"
     - key: "connection_id"
       value: "local-k8s"
+    - key: "aws_conn_name"
+      value: "aws_default"
     - key: "in_cluster"
       value: true
     - key: "model_training_configmap"

--- a/flux/clusters/bridgeai-prod/airflow/values.yaml
+++ b/flux/clusters/bridgeai-prod/airflow/values.yaml
@@ -29,6 +29,13 @@ airflow:
           "namespace": "airflow",
           "disable_verify_ssl": true
         }
+    - id: aws_default
+      type: aws
+      extra: |
+        {
+          "region_name": "eu-west-2",
+          "role_arn": "arn:aws:iam::058264114863:role/airflow-access-role"
+        }
   connectionsUpdate: true
   variables:
     - key: "data_path"

--- a/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
+++ b/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
@@ -9,6 +9,8 @@ spec:
   interval: 1m0s
   ref:
     branch: bug/fix_upstream_bitnami_uri_protocol
+  secretRef:
+    name: flux-system
   url: ssh://git@github.com/digicatapult/bridgeai-gitops-infra
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
+++ b/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
@@ -9,8 +9,6 @@ spec:
   interval: 1m0s
   ref:
     branch: bug/fix_upstream_bitnami_uri_protocol
-  secretRef:
-    name: flux-system
   url: ssh://git@github.com/digicatapult/bridgeai-gitops-infra
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1

--- a/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
+++ b/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: main
+    branch: bug/fix_upstream_bitnami_uri_protocol
   secretRef:
     name: flux-system
   url: ssh://git@github.com/digicatapult/bridgeai-gitops-infra

--- a/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
+++ b/flux/clusters/bridgeai-prod/base/flux-system/gotk-sync.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   interval: 1m0s
   ref:
-    branch: bug/fix_upstream_bitnami_uri_protocol
+    branch: main
   secretRef:
     name: flux-system
   url: ssh://git@github.com/digicatapult/bridgeai-gitops-infra

--- a/flux/clusters/bridgeai-prod/cert-manager/source.yaml
+++ b/flux/clusters/bridgeai-prod/cert-manager/source.yaml
@@ -6,4 +6,5 @@ metadata:
   namespace: cert-manager
 spec:
   interval: 10m
-  url: https://charts.bitnami.com/bitnami
+  type: "oci"
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/flux/clusters/bridgeai-prod/mlflow/source.yaml
+++ b/flux/clusters/bridgeai-prod/mlflow/source.yaml
@@ -6,4 +6,5 @@ metadata:
   namespace: mlflow
 spec:
   interval: 10m0s
-  url: https://charts.bitnami.com/bitnami
+  type: "oci"
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/flux/clusters/bridgeai-prod/prediction-service/source.yaml
+++ b/flux/clusters/bridgeai-prod/prediction-service/source.yaml
@@ -15,4 +15,5 @@ metadata:
   namespace: prediction-service
 spec:
   interval: 10m0s
-  url: https://charts.bitnami.com/bitnami
+  type: "oci"
+  url: oci://registry-1.docker.io/bitnamicharts

--- a/flux/clusters/bridgeai-prod/secrets/ghcr-io-kserve.yaml
+++ b/flux/clusters/bridgeai-prod/secrets/ghcr-io-kserve.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    .dockerconfigjson: ENC[AES256_GCM,data:r7LG1Xnou/iZ7uwe79NK6I0Ro9xolkuz8eKzMjWil5kWeSS4Mk3GoJkq6e+kzemZhEDmwzSs4p1TSUGDlJYvPZZm8zjCPsCTaAHWmSbzOYRG+3ui8LvoiBpm28tBzsm6WoWCftrqx6idV+MZG6eV2R3TiwTBLBbcz4YLhRvmMAQ4kLPbvvDYdb47mmqchmY6sdoveSWUkSDufXJn6ofgw8FOAbSTK6Bk1K35cF/VAlvkIRKnYYiKuCPOjKsVaMmYUmiUtzkYpffCtDtU1fwuhQiS8M4U/YlLP/vKs0+2j5cWBFomnLkrW4DarqybyFf/s67szfBrxKw=,iv:Tg9p1GgrSFgpuvBRqhCHaSbToll5RbldQTS13B39BxA=,tag:jFRiHU8xv5Ch0f08V9q3rQ==,type:str]
+    .dockerconfigjson: ENC[AES256_GCM,data:YZkULPgnhjJTh2d+WpgZ/1Ag81xWfgMYVTa+9j0oLuQlHC+vsf3T2a90eaojsP61HbX0qT4OvSrKmam4kYR9AoKwaRQgWGZm6+BZDHGyzTNdLwALkhSSXPJukMdLlZ5wWDxTPK5WHyrZ9gslTZ+ulx9+1n4aCUO2FoT+6gi+/iniuUzSZc4x37ayHHDVb1+S6hadhnvJoNDh9hHCZfRVcyoMpxr9JZMWW8XK9cwLRK+Cyj+HHfiXEa6ekqlLpYitcmzmgvcCa/t8VXurDO54XMBoep3qRifQOf7w5YoBYBpk+rfVFp81zE1323nlt9sXP03VnQ==,iv:53rshwAO4HChS0bqddg2tAO9RFmkBRhh9ldjmUSEK3g=,tag:1ISZPZ/76f6ZTb4W3BsXdQ==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -13,29 +13,29 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-23T11:00:22Z"
-    mac: ENC[AES256_GCM,data:BMO931aJv9hacuk4LNdj3HLvdAko07WF93w/fysn5sdatyQo/9zyE//044odfzA6LfYL9GKsMrVEVC9yBvle3MgrQs5YT1TkDqyTlZrRG8e2h1Fms7D3sJ2gOU3rmMBtkW+WieiN2rWZMGDGexlBll6a47KkPKFc9TieqIz+C38=,iv:Z8jFwHnhFHnfW7UmhjsCqsSBurW3BQ2yZ5bdwqxyvI4=,tag:r9PtOtKUKjBhloPBosizlw==,type:str]
+    lastmodified: "2025-01-15T13:23:22Z"
+    mac: ENC[AES256_GCM,data:NfMdU7hWO268/1iHEtc/YE+pRdjMuHwXbzJAsHLgXjdx4i10ytr+ir59VamjQip2Jj22Mt0VNEsSXZNVXvvG/jqIGS9ZdiO3CmL0+KTQQpsRJfSbDBut5rD2g26J2ZkRZVxW+aVv0QlRdvQzmDv5VVPcZhFu8wy2hlZ0SXyMBIo=,iv:8zmu0RtNISTDbLTthyzzoIFcinWTdp1n0d29Nd/Vsvg=,tag:nSCCv2Bu4gmXO2XZ7wPJFQ==,type:str]
     pgp:
-        - created_at: "2024-10-23T11:00:22Z"
+        - created_at: "2025-01-15T13:23:22Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0/EQbQcE5PUAQ/9E439vtvodKPIhjNpbM+8s9AAU0l+xG2P1sZAppkYXIJF
-            aeSpFa15t18XjXLqri2ln7ZDhhkCPeraOUxdu2K0x8/N66orZGtlO/IigBHTYtUd
-            ciV5DuhvQdeV49M/GIPDRkS9EMbjPj+MzsSPNg2vPxqT9Oy/AKyZfFTzZD8AqIxm
-            upg4WjIq67SGaXUxemxdYWXGI5A697EQh4H9vLkxxTJHv9oehIeuQnSilXEyTw9V
-            zeITDwqM8zx/vGv9U51qzCncjdStZ2VLqJvn9NOrYlj82ydOB2PVCzQQgkcrmLPq
-            09VVsFHq6qEiPiLLYuMp3VK4n8s5Um4XzeFKUKU0FE10sB+/lYtfbIAaiDnLOfSn
-            /tE+cwm3iyvKZkwqt/lj+x6rMM/ZMng8mCiq1M935cDgwXPoxB1jxyyuz3QtcJlC
-            1UWMdkhXtmGwyzoNbY3NUFISFBU1ME/BHg0hd6iJ6aKegQrQUI6QIy91EN2t1MGN
-            3VTsmxppKO0tLSzxgYlRxOs/W2s+JdjWERfvl9oMs2Tad5rF6BZiS4kGtyya7xeq
-            wPhKhKW5JPrjgUpZ5dhgX5BI4jWq/zOYwWxHxRNsPD0JO9khXvP0tE0s4Rmi/wwo
-            kQ1jyhoJdcpwm7y49PeuIEQk0f5cs1UVi3nzNMSEUsBHF3Hz+gAF5q8XbdSGN2HU
-            ZgEJAhBXXM058S08j/7wtN83dJjRoaTuorXLeBIU9B0ahCVOir8K3dKlJnHXZhlc
-            yRfZsQYR7MEqDu28sErhTl9sojuEn9N1ojAZQ1qwvZWNFIlHP9YBYDY6Gagi1433
-            xqGRQzZjYg==
-            =TX4I
+            hQIMA0/EQbQcE5PUARAAnpUKwj/tPMvL3QQ4sytS+qzh20D8sSdZZi3PjQUL/UQQ
+            2IVzEENvYi5cFSCDvRmEo403xsfGV9YLIOURAwiNb35bqo5yWr40INLJDMJyT+mg
+            djvPNb4+oTqnIT0DsyQXtPvubR5pZwj78zGzdE9XgFy8Xx/MI7D5tLXnIHdFDged
+            p30+4h2oBEnUBudFBAd8/wvza6GfriN7I8Sx7i5PY1g2ASFjQjlEInAKsiAgBaeM
+            oYcTuMfS79VA1jYbNfPWOFywYLFRdCe3zRl4B8dF0SIiyFVfOmYOQqaBLCp+J0Xq
+            mJQnUvoucBUCN9wIxC1veCoZpeSO/Kydz7kQ2mpbg2aN5yl0o4HmfRNvo4MbiFNI
+            MzUkYawAZ3o34hVHuCAQbP+i4tmk2e+Q2zOOKrFbTvogTtPt8zy8ov50mtI8a+VN
+            AXTpq4vPzzkARwVdUYkk+Hkw1EFo8z9w40gfx67reXclZWGp0FQq6jfnxI6HIXj+
+            onRZn8zvRgP8TAl7SelIxCg+kMIQxM17QDYixwdr3U+VXZHRHkVG4kN5X/Qhaloh
+            5/chqMhjmQwyZhDNHZ5x8kn6P2HTNYYX7vyX4mqGyhMyDDcwznGAeaFPKcNCuNbG
+            SyhBIK6qkCuGSucfWMXlikWoPm37wVI1uzjzpQ4G2A3wWrsXaVEGcI24bb1t1HDU
+            aAEJAhBUw/MMZ6legPZcFFitZ7SORfYlq/JrQ/Sknt64JS5bk/gCNj/4zcnxLoLv
+            mjYL5pKM56r0ftti0py5zlqqiTRZ4cfIfEi/sEj9ime/MuqmLu4jAHE30Fa+tHuN
+            MjKRnjX5XAcE
+            =QYhs
             -----END PGP MESSAGE-----
           fp: 2B78BF99642CE90A7ACF9284C13A02BF95797BCD
     encrypted_regex: ^(data|stringData)$
-    version: 3.9.1
+    version: 3.9.3

--- a/flux/clusters/bridgeai-prod/secrets/ghcr-io-kserve.yaml
+++ b/flux/clusters/bridgeai-prod/secrets/ghcr-io-kserve.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-    .dockerconfigjson: ENC[AES256_GCM,data:YZkULPgnhjJTh2d+WpgZ/1Ag81xWfgMYVTa+9j0oLuQlHC+vsf3T2a90eaojsP61HbX0qT4OvSrKmam4kYR9AoKwaRQgWGZm6+BZDHGyzTNdLwALkhSSXPJukMdLlZ5wWDxTPK5WHyrZ9gslTZ+ulx9+1n4aCUO2FoT+6gi+/iniuUzSZc4x37ayHHDVb1+S6hadhnvJoNDh9hHCZfRVcyoMpxr9JZMWW8XK9cwLRK+Cyj+HHfiXEa6ekqlLpYitcmzmgvcCa/t8VXurDO54XMBoep3qRifQOf7w5YoBYBpk+rfVFp81zE1323nlt9sXP03VnQ==,iv:53rshwAO4HChS0bqddg2tAO9RFmkBRhh9ldjmUSEK3g=,tag:1ISZPZ/76f6ZTb4W3BsXdQ==,type:str]
+    .dockerconfigjson: ENC[AES256_GCM,data:gXTAsXzeZkQEInSQX4MDF4SiRlWal75IsrcqxZ9Tqnnckir8lq83KZ717OW0zldLZA3iwlCmx5pDZk6d/933hFn6otALgiuhnOrRZHGZcycwhj7bB0dO2Wx1KXGqIBa7SWHtNfgugIzfaXGPYgAYoSKlphsOJvKbUJPaSiTZlpZB6m8l6EZziLmofmJ/75AuKzaRnme4VIK4LruEOjm3iVlC5TBVAoE716OnqspdYWKVxM2VrM7HsIsdlkXwFGL/aeOElcohYx7JiZkhCxo3mPG/lHFIb5WpykS0y9mnIOpkS6EbqTQzoL60DpgTmGOGg6GI0bRSp/YQGU43eGlAsjpO4L/y30JynO8rC+9YsSyVz6yaUN3uXv5kjMJbKjmIXqQIdFoclI/f1HCbBqYLOSaXEwp8HqSjBdZeKgNN3R0BNrmnaGJFjsuZRUm1e8lRLWs3ECy1L3mMmeCd9gpiJpVdMO4SkCDTt1ofvwsSaF/IVpPt,iv:k0mpprM3V2LK2PGNM3E6ZmTZNLPthSg/zzpTL15PQXM=,tag:/6v4fY2C8G1ayY5gk3Y1fg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
@@ -13,28 +13,28 @@ sops:
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2025-01-15T13:23:22Z"
-    mac: ENC[AES256_GCM,data:NfMdU7hWO268/1iHEtc/YE+pRdjMuHwXbzJAsHLgXjdx4i10ytr+ir59VamjQip2Jj22Mt0VNEsSXZNVXvvG/jqIGS9ZdiO3CmL0+KTQQpsRJfSbDBut5rD2g26J2ZkRZVxW+aVv0QlRdvQzmDv5VVPcZhFu8wy2hlZ0SXyMBIo=,iv:8zmu0RtNISTDbLTthyzzoIFcinWTdp1n0d29Nd/Vsvg=,tag:nSCCv2Bu4gmXO2XZ7wPJFQ==,type:str]
+    lastmodified: "2025-01-15T14:38:29Z"
+    mac: ENC[AES256_GCM,data:eaX/IUHfCnn9i1iYyukoR4kWQ6osnvm3WkC77Fx2B5QI9tY1cPjkR559veun0QDbabzYb1CvcMNe2BR32NQOMxUduHNXyT3BpDG8RUI5EgR9jRssMzzSFwtgPq3kpKkknEvkz/cL+Bz6v5LO2opCtiyR8ynt/14oMHKELjTrx3E=,iv:+jLNcAN1HeRQ62VroIN6u9uInuzmvCQi3I1ktD2o0ds=,tag:Vhthb/6YMUhpA+PiJsyx6w==,type:str]
     pgp:
-        - created_at: "2025-01-15T13:23:22Z"
+        - created_at: "2025-01-15T14:38:29Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0/EQbQcE5PUARAAnpUKwj/tPMvL3QQ4sytS+qzh20D8sSdZZi3PjQUL/UQQ
-            2IVzEENvYi5cFSCDvRmEo403xsfGV9YLIOURAwiNb35bqo5yWr40INLJDMJyT+mg
-            djvPNb4+oTqnIT0DsyQXtPvubR5pZwj78zGzdE9XgFy8Xx/MI7D5tLXnIHdFDged
-            p30+4h2oBEnUBudFBAd8/wvza6GfriN7I8Sx7i5PY1g2ASFjQjlEInAKsiAgBaeM
-            oYcTuMfS79VA1jYbNfPWOFywYLFRdCe3zRl4B8dF0SIiyFVfOmYOQqaBLCp+J0Xq
-            mJQnUvoucBUCN9wIxC1veCoZpeSO/Kydz7kQ2mpbg2aN5yl0o4HmfRNvo4MbiFNI
-            MzUkYawAZ3o34hVHuCAQbP+i4tmk2e+Q2zOOKrFbTvogTtPt8zy8ov50mtI8a+VN
-            AXTpq4vPzzkARwVdUYkk+Hkw1EFo8z9w40gfx67reXclZWGp0FQq6jfnxI6HIXj+
-            onRZn8zvRgP8TAl7SelIxCg+kMIQxM17QDYixwdr3U+VXZHRHkVG4kN5X/Qhaloh
-            5/chqMhjmQwyZhDNHZ5x8kn6P2HTNYYX7vyX4mqGyhMyDDcwznGAeaFPKcNCuNbG
-            SyhBIK6qkCuGSucfWMXlikWoPm37wVI1uzjzpQ4G2A3wWrsXaVEGcI24bb1t1HDU
-            aAEJAhBUw/MMZ6legPZcFFitZ7SORfYlq/JrQ/Sknt64JS5bk/gCNj/4zcnxLoLv
-            mjYL5pKM56r0ftti0py5zlqqiTRZ4cfIfEi/sEj9ime/MuqmLu4jAHE30Fa+tHuN
-            MjKRnjX5XAcE
-            =QYhs
+            hQIMA0/EQbQcE5PUAQ/+JZrwbu5drkFIt9n6hTQrCNV5Y5FggvCgrXeOs02leYsA
+            6I3RYWo6/50pStqOefkrdC5EUy3uqE6rk+W+DMugc3nW2q/J3ECD7QUB/LmB5TXF
+            p+H6CJEm57PvA9q+p/4r3aNN4JHvTOd3fDeoAF0gU/lRMGlqUAxJiF/XSwQEC2jb
+            CyMd5op9fZW/uNapSpBE/FyZKqfeOVHNYMvkAmjzAt4a2F+DAzdmVPDS6T8KQBDg
+            5Hwv82fjlRkYFAH8IYmw1PpD4jHwcu5r7co5c5ZOa55lUFWX9H+2QqX+kvA6cK1y
+            VtKnMAWF325MOcq17D7uQYaUaFn05AB6LcRDFa3NTAO2YvS5qXvYLzs/CcXxwwec
+            J1/Fr0JNJwQ31k2rNcoFmT4bt5qa9aBB8bADPTNNyEwg2m7kuQktJnKStgzGAFjf
+            rHIaS/jDqdVDEO2d9HwCsf71o/wtuKRGmhdwr2IOOnoj3qIp0JPK1VmJfMIK8ASU
+            PzpyK1756H5Qc1VrswbPvXZrH8yGOLgOk2gBllTaqXcEqWpDeX8SyeOUqoNps6df
+            p9lxA98dvrQzg0NZd8VWTb8LEs5l6Xos7Nq7KMg6VVUjaU0KHPdtQ9W3YsM5eAzZ
+            QE/xSfSpUU54/pNpArq+1fVcNxvBnCf6jDREtagh/2IUpmsEam+X3muepsTfdwLU
+            aAEJAhDjuhBpBTA6iwEvbg9bUhgM9ynKTP3fBufR2lO9TEYZkvM6+BBSXYYcKfnG
+            n0aKRkcXyY93ZFsjppqWY81H1zssG9AEfdj9i9bf4UoEckOO5cCQeeyNGpFDryMk
+            d33wzBL9QDfC
+            =r8dy
             -----END PGP MESSAGE-----
           fp: 2B78BF99642CE90A7ACF9284C13A02BF95797BCD
     encrypted_regex: ^(data|stringData)$

--- a/flux/clusters/bridgeai-prod/secrets/ghcr-io.yaml
+++ b/flux/clusters/bridgeai-prod/secrets/ghcr-io.yaml
@@ -1,40 +1,41 @@
 apiVersion: v1
 data:
-    .dockerconfigjson: ENC[AES256_GCM,data:Jdwfnl2dcUN+nbeS713tvwyce3pM0kIRnjR1aQzr4qnogIG/C3YO/9Jln7v9o+RBG16wpWnPw+hJRgOln9Q9JHejblYa/s+BEyq8dCxifelzAvPbrjoxslt92k9r7gX2nENEvlSic0e/IhArT2ns2Hv8A53WvyuLJIB/v0gOUdkKhXB6Zz4+u0B3zhqXORNDXfsJZ9BbkzTSQSv4tba4jaOzGtF1N/giyqWtp0KSPAkImLvlTdsddIX0DzzPVHZ7W2v6kQIPhpRtSJdPW7JdjrPb4w1MMqEXNSYS2afRE6JWKeGp6Z9JkQLeSF1n9ie3dMZAuMslh75eJjgiMdi8d5+MgO63u6tDQWrJ+6v2Htgo5u3aPu4w4ePSZZ9NTdSW+zN+E/YRTzsdJxh6ekaH1T43NtCtPjlbt1q82Q==,iv:BgheP/oIMyPsiMeC9s7DxEozGST9U2Ah6gkYRfc1QE8=,tag:c214JYBg8OkJg7JAau27Zg==,type:str]
+    .dockerconfigjson: ENC[AES256_GCM,data:Y3NeGgfeggxhbF1WO86JfDps9ABusbs/QzmY7LDubnNum80glH/GEBczOlG+MwSaBBvqamQtsububxkxHPd4v7ObfpxQaK3LU3EoX6Staj7d9UVyHbEadAeQx2GIo6o3neHX3P3LOjIP4EW87l0izHkqtQvr54KMx6J9sOJmUN0zIxMnnMe02k7eu8c/vwbhe5sXvDHr37vvQF/K2BPAZYWyzU7jIbw9X3l9KALTkYzbsRIlspsho32QJ1Xe/lhhyDlx5CIizyaRqKlfrKzBzuzteO5V5F0oj6vdnT9aKvl9z5S2AePwJj0znI5nF7IaYRQC++kvzN3uI1kI+BMqhkDdBzOaVUPH+2x5EH75KAX9tCO3pJlnjnYKObOAXlnyqtcc86vh9Gl79sulLlNlzI/8DXBSqVpkm0J5hhEh1fkwDHeLQiMkefWpGj2r+tLpr7mOFqMYtN2CxDc+lbm/Oyic9guoklLBEHbWUIsN0OgrYKob,iv:BCdK2HP52HwaAodP7lvQg2X+E0FNPc2UOPuBFMpW31U=,tag:DIFpLjUKsHofmqCrSXOmkg==,type:str]
 kind: Secret
 metadata:
     creationTimestamp: null
     name: ghcr-io
     namespace: airflow
+type: kubernetes.io/dockerconfigjson
 sops:
     kms: []
     gcp_kms: []
     azure_kv: []
     hc_vault: []
     age: []
-    lastmodified: "2024-10-15T16:59:17Z"
-    mac: ENC[AES256_GCM,data:Rbg9GQPSiXzRAHLWdsE1Cca79BpCnpgnxAYroOuC+7moVeCyBiu+lbS0iyFxhjH8FL/DrQk7lYYmznMDE1fX/muHMlSDemm8xaxIGnnrmkpxcnC6mistTLwx4fGGSp9sbIqIPDPqaS2ZYeEnd2yW/ITP6YBPpbiKL7saR2vX6D0=,iv:xVumfRR7v8EBQhwWtDvHC2853xsQhCTvuEz83GHvSSo=,tag:Ll+Rc9M73f6HZfT4T6W71Q==,type:str]
+    lastmodified: "2025-01-15T16:35:13Z"
+    mac: ENC[AES256_GCM,data:0rutrNzRRE4r0UFoObqsTA/ah6lLk1Bs6Pam5VwCt60u8AjCMSymqbgYYkYxcVjPgfQ7+lLOBjavULXj3VmgesgnwE34bR26InkoycWZZPltn34PBWHy84lxuHTCsn7vbf24gzI5neW4U1+hFs9t54hOe2fgQ2z7FS7xs1iOuEk=,iv:jnbhKSkYdV482NLDO3YVHfwky/glkHr6O1tVns8nEj8=,tag:/DgXRtb9+o0cmCzhyzN1TA==,type:str]
     pgp:
-        - created_at: "2024-10-15T16:59:17Z"
+        - created_at: "2025-01-15T16:35:13Z"
           enc: |-
             -----BEGIN PGP MESSAGE-----
 
-            hQIMA0/EQbQcE5PUARAAuAzKITmrLU2BO6WQlP2Gz+t7J4e9QUY/UN3PeQdSabIO
-            OHqH2lsl/Ss1k0PWu42DkYGcMPNk97jVF4FNSoDWr2fvYId1H04CH8ytWVX8l9mq
-            VBIbno1SOzSxSQD+R37AbNZoJfgjVDykWFU1PWHmeneCYKLl/Hn1EdVAfCDsskOA
-            HwgetmUDWHDmY3WWDd0NHA0T6X8xhn+H3I/3Upi1+DH56FXEdEffyFdGKy64sARB
-            ozUSh2lDigv22GxqDh2qBSYbiDi3SP8sjCe5rxn2TifitqiufaejfuK3J5p7XhmM
-            cqu91dTnsvPWCBZs9T6OVGjHmw21+J7UhRro/tufKc9mka0cDNtrAL3ycjrAO5Dm
-            nXDw2UL9M9jSPBJGttIT/4N3hWhk65EdNE+8WLdRGboxigXxOhtUik93dKEw97n+
-            LTdhuMeFgDdssp1lups/ZqSmzhVFKhtn4Oe9+RTUXQD/jCzCyzlj7Gs+GUOCB+n4
-            CkZleVBxz2yvwMNT+z79LWy70+NwGVF5Detk8zI/KpplBUJtJE2eYFE9ZZ36q5MU
-            tEiuT0DPEJgluRM88OGQeGndBXZuQG1hOfKiGRHKFNnWLyWu+i5nk0oL/9oY/ZLf
-            6eCFBmHMSyJhWYmQ/b6UVjFf6O0yAuYPzdcQprF+5iS3hmtrIYDTmWPtMA9PWInU
-            aAEJAhBmCWnPXs54cNAsXmSxHl0w3byWnuLHkJFLzCtjWVTEGI98Y5xH3j3aGUqr
-            m1ISTW7+spz+/CJSPyOcMPIjvSCOdb5VrW+beUGZyG++baI+Q4SS74N3aqtwnjQ/
-            LAx9PbbkgSdX
-            =biAm
+            hQIMA0/EQbQcE5PUARAAj3R/0933k7R2SztsnNbA6dVsbQdP0T7KtD4gS6He8m2C
+            5F8srGBuWUcJ3gCUumWsXec5bV+9M4vDIFCD1g74BK6MsiuJuzGiYVoD0fn34H3w
+            nO5h6agq5YV9U83SfY6xV9XxuiyE5Q5emtdRLXktmNZotPwBnspGOi/ZtANXf9af
+            kvqOMreYEDg3CR8oVgS282HKNn4a0klSvnr1FGqMAEOMbQtQlA51ECrKR+2Nb2dX
+            5VRiGO0W7MGrR8EyE63WEibM32Rrg9zePY/lfPiijstqAzH60VymDxbUy0p7b37T
+            FMh3NJZGYnAstLqfxtAKS8llHyghfYCqV5r3xmVvxZEhdI2hDlI9HVCColkQ2K+v
+            huijXsoohUiu1MLnHxQPbsVITUk5wMay88+Hbyz7jrNiqa6QAa9TLKtm2g3J+f5L
+            60/F1QhIyFlcsep0i4mGsufWpbB270dgfhie8Mw3cEf/6NAtMRY2SkWqdSsQxH2Q
+            SuPUlYNKpW4NZ9U4r542OkqvcZkIz1GUd+c0d9SNfS6EVr4Qz8DKRlaurcmZTHeY
+            khfYx8i3yMawUOE+1ToQJt6cBS1dnNup093PXm88n7ZcG8626bX13m5dKsyT2lnh
+            F0pxggKdG3Qz+yrCGSwmOGwT1cW95Hl6lfAExQrpkK4NI6I0kz4udNgsaPr2BKjU
+            aAEJAhBiruyVS2+0D+Amzm5cPsf+DzqIqqSY5HP3OQfBXAwKJ7mN7VcjBcoi3T7R
+            L1mUDfGqmi0mbbZMhyEKbEus7XJA2lDJTub8hTcUBUv5mMQ04xtIOXlP3k5nTLNd
+            xO1pli3MZewa
+            =09+N
             -----END PGP MESSAGE-----
           fp: 2B78BF99642CE90A7ACF9284C13A02BF95797BCD
     encrypted_regex: ^(data|stringData)$
-    version: 3.9.1
+    version: 3.9.3


### PR DESCRIPTION
# Pull Request

## Checklist
- [x] Have you read Digital Catapult's [Code of Conduct](https://github.com/digicatapult/.github/blob/main/CODE_OF_CONDUCT.md)?
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.

## PR Type

Please delete options that are irrelevant.

- [x] Bug Fix

## High level description

1. Bitnami have implemented a fundamental change to how their charts are structured and sourced, effectively switching to the OCI format across the board. This requires a corresponding change to all downstream references in YAML (`*/source.yaml`), to include the OCI schema and Bitnami's charts on the Docker Hub.
2. There's an expired secret for Kserve that also needed updating.